### PR TITLE
Added Intel Dual Core T2390 to whitelist

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -46,6 +46,8 @@ std::vector<std::string> cpu_whitelist = {
   "E5520"
   // Intel Core2 Duo T6500
   "T6500"
+  // Intel Dual Core T2390
+  "T2390"
 };
 } // namespace
 


### PR DESCRIPTION
Added Intel Dual Core T2390 to whitelist as it supports SSSE3 but was unable to install anbox prior to this